### PR TITLE
deps: Bump token-2022 and token-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8750,9 +8750,9 @@ dependencies = [
 
 [[package]]
 name = "spl-elgamal-registry"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65edfeed09cd4231e595616aa96022214f9c9d2be02dea62c2b30d5695a6833a"
+checksum = "56cc66fe64651a48c8deb4793d8a5deec8f8faf19f355b9df294387bc5a36b5f"
 dependencies = [
  "bytemuck",
  "solana-account-info",
@@ -8764,11 +8764,12 @@ dependencies = [
  "solana-pubkey",
  "solana-rent",
  "solana-sdk-ids",
+ "solana-security-txt",
  "solana-system-interface",
  "solana-sysvar",
  "solana-zk-sdk",
  "spl-pod",
- "spl-token-confidential-transfer-proof-extraction 0.3.0",
+ "spl-token-confidential-transfer-proof-extraction 0.4.0",
 ]
 
 [[package]]
@@ -9024,9 +9025,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "8.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f0dfbb079eebaee55e793e92ca5f433744f4b71ee04880bfd6beefba5973e5"
+checksum = "707d8237d17d857246b189d0fb278797dcd7cf6219374547791b231fd35a8cc8"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -9052,12 +9053,12 @@ dependencies = [
  "solana-system-interface",
  "solana-sysvar",
  "solana-zk-sdk",
- "spl-elgamal-registry 0.2.0",
+ "spl-elgamal-registry 0.3.0",
  "spl-memo",
  "spl-pod",
  "spl-token 8.0.0",
  "spl-token-confidential-transfer-ciphertext-arithmetic 0.3.0",
- "spl-token-confidential-transfer-proof-extraction 0.3.0",
+ "spl-token-confidential-transfer-proof-extraction 0.4.0",
  "spl-token-confidential-transfer-proof-generation 0.4.0",
  "spl-token-group-interface 0.6.0",
  "spl-token-metadata-interface 0.7.0",
@@ -9068,9 +9069,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token-client"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110082393ab2f9129e23a58c7cdd94f751096937ba190110a7f0d6e8685dcb63"
+checksum = "4c063f31347dec4286beec6e568c70059d27295c1b013711c26c84d52a60a1e7"
 dependencies = [
  "async-trait",
  "bincode",
@@ -9084,12 +9085,12 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-sdk",
  "spl-associated-token-account-client",
- "spl-elgamal-registry 0.2.0",
+ "spl-elgamal-registry 0.3.0",
  "spl-memo",
  "spl-record",
  "spl-token 8.0.0",
- "spl-token-2022 8.0.1",
- "spl-token-confidential-transfer-proof-extraction 0.3.0",
+ "spl-token-2022 9.0.0",
+ "spl-token-confidential-transfer-proof-extraction 0.4.0",
  "spl-token-confidential-transfer-proof-generation 0.4.0",
  "spl-token-group-interface 0.6.0",
  "spl-token-metadata-interface 0.7.0",
@@ -9137,9 +9138,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2629860ff04c17bafa9ba4bed8850a404ecac81074113e1f840dbd0ebb7bd6"
+checksum = "bedc4675c80409a004da46978674e4073c65c4b1c611bf33d120381edeffe036"
 dependencies = [
  "bytemuck",
  "solana-account-info",
@@ -9285,7 +9286,7 @@ dependencies = [
  "solana-sdk",
  "solana-test-validator",
  "spl-tlv-account-resolution 0.10.0",
- "spl-token-2022 8.0.1",
+ "spl-token-2022 9.0.0",
  "spl-token-client",
  "spl-transfer-hook-example",
  "spl-transfer-hook-interface 0.10.0",
@@ -9303,7 +9304,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution 0.10.0",
- "spl-token-2022 8.0.1",
+ "spl-token-2022 9.0.0",
  "spl-transfer-hook-interface 0.10.0",
  "spl-type-length-value 0.8.0",
 ]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -29,8 +29,8 @@ serde_yaml = "0.9.34"
 
 [dev-dependencies]
 solana-test-validator = "2.2.0"
-spl-token-2022 = { version = "8.0.1", features = ["no-entrypoint"] }
-spl-token-client = "0.15.0"
+spl-token-2022 = { version = "9.0.0", features = ["no-entrypoint"] }
+spl-token-client = "0.16.0"
 spl-transfer-hook-example = { version = "0.6.0", path = "../../program" }
 
 [lints]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -19,7 +19,7 @@ forbid-additional-mints = []
 arrayref = "0.3.9"
 solana-program = "2.2.1"
 spl-tlv-account-resolution = "0.10.0"
-spl-token-2022 = { version = "8.0.1", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "9.0.0", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.10.0", path = "../interface" }
 spl-type-length-value = "0.8.0"
 


### PR DESCRIPTION
#### Problem

The new token-2022 and token-client crates are available, but not being used in this repo.

#### Summary of changes

Update both packages at once to avoid build failures, as in the dependabot PRs.