### PR TITLE
CI: Don't run semver job for cli package

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -77,9 +77,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
+        if: ${{ inputs.package_path != "clients/cli" }}
         uses: actions/checkout@v4
 
       - name: Setup Environment
+        if: ${{ inputs.package_path != "clients/cli" }}
         uses: ./.github/actions/setup
         with:
           cargo-cache-key: cargo-publish-semver-${{ inputs.package_path }}

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -86,16 +86,19 @@ jobs:
           cargo-cache-fallback-key: cargo-publish-semver
 
       - name: Install cargo-semver-checks
+        if: ${{ inputs.package_path != "clients/cli" }}
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-semver-checks,cargo-release
 
       - name: Set Git Author (required for cargo-release)
+        if: ${{ inputs.package_path != "clients/cli" }}
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
       - name: Set Version
+        if: ${{ inputs.package_path != "clients/cli" }}
         run: |
           if [ "${{ inputs.level }}" == "version" ]; then
             LEVEL=${{ inputs.version }}
@@ -105,6 +108,7 @@ jobs:
           cargo release $LEVEL --manifest-path "${{ inputs.package_path }}/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
 
       - name: Check semver
+        if: ${{ inputs.package_path != "clients/cli" }}
         run: pnpm rust:semver --manifest-path "${{ inputs.package_path }}/Cargo.toml"
 
   publish:


### PR DESCRIPTION
#### Problem

The semver job is failing during publish because the CLI package has no lib target.

#### Summary of changes

I went through a few iterations on this, including a complicated cargo metadata | jq command to see if there were any lib targets on the crate, and then decided it would be easier to just not run the job for the cli package.

And then while doing that, I found out that there's no way to easily say:

* don't run a set of steps
* still mark the job as successful for later jobs that require it to be successful

So I added the "if" line to a bunch of steps in the semver job.

I remember you did something similar for another repo, but I couldn't find the eventual solution. Let me know what you think!