### PR TITLE
Update transfer hook interface link

### DIFF
--- a/program/README.md
+++ b/program/README.md
@@ -4,7 +4,7 @@ Full example program and tests implementing the `spl-transfer-hook-interface`,
 to be used for testing a program that calls into the `spl-transfer-hook-interface`.
 
 See the
-[SPL Transfer Hook Interface](https://github.com/solana-labs/solana-program-library/tree/master/token/transfer-hook/interface)
+[SPL Transfer Hook Interface](https://github.com/solana-program/transfer-hook/tree/main/interface)
 code for more information.
 
 ### Example usage of example


### PR DESCRIPTION
Update the program README.md to point to the correct transfer hook interface link. Previously it was pointing to a dead link (https://github.com/solana-labs/solana-program-library/tree/master/token/transfer-hook/interface)