### PR TITLE
interface: Demote all signers during onchain invoke

### DIFF
--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -30,7 +30,7 @@ spl-pod = "0.7.1"
 thiserror = "2.0"
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [lints]
 workspace = true

--- a/interface/src/onchain.rs
+++ b/interface/src/onchain.rs
@@ -51,6 +51,9 @@ pub fn invoke_execute<'a>(
         )?;
     }
 
+    // Demote all signers
+    cpi_instruction.accounts.iter_mut().for_each(|a| a.is_signer = false);
+
     invoke(&cpi_instruction, &cpi_account_infos)
 }
 

--- a/interface/src/onchain.rs
+++ b/interface/src/onchain.rs
@@ -511,4 +511,21 @@ mod tests {
             assert_eq!(a.is_writable, b.is_writable);
         }
     }
+
+    #[test]
+    fn test_signer_demotion_sanity() {
+        // This test doesn't actually run any functions in this file, but checks
+        // that demotion works as expected.
+        let mut instruction = instruction::execute(
+            &Pubkey::new_unique(),
+            &Pubkey::new_unique(),
+            &Pubkey::new_unique(),
+            &Pubkey::new_unique(),
+            &Pubkey::new_unique(),
+            100,
+        );
+        instruction.accounts.push(AccountMeta::new(Pubkey::new_unique(), true));
+        instruction.accounts.iter_mut().for_each(|a| a.is_signer = false);
+        assert!(instruction.accounts.iter().all(|a| !a.is_signer));
+    }
 }

--- a/interface/src/onchain.rs
+++ b/interface/src/onchain.rs
@@ -52,7 +52,10 @@ pub fn invoke_execute<'a>(
     }
 
     // Demote all signers
-    cpi_instruction.accounts.iter_mut().for_each(|a| a.is_signer = false);
+    cpi_instruction
+        .accounts
+        .iter_mut()
+        .for_each(|a| a.is_signer = false);
 
     invoke(&cpi_instruction, &cpi_account_infos)
 }
@@ -524,8 +527,13 @@ mod tests {
             &Pubkey::new_unique(),
             100,
         );
-        instruction.accounts.push(AccountMeta::new(Pubkey::new_unique(), true));
-        instruction.accounts.iter_mut().for_each(|a| a.is_signer = false);
+        instruction
+            .accounts
+            .push(AccountMeta::new(Pubkey::new_unique(), true));
+        instruction
+            .accounts
+            .iter_mut()
+            .for_each(|a| a.is_signer = false);
         assert!(instruction.accounts.iter().all(|a| !a.is_signer));
     }
 }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -29,7 +29,7 @@ solana-sdk = "2.2.1"
 solana-system-interface = "1"
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["cdylib"]
 
 [lints]
 workspace = true

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -29,7 +29,7 @@ solana-sdk = "2.2.1"
 solana-system-interface = "1"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
#### Problem

There's just too many ways for signers to be potentially abused during transfer hooks.

#### Summary of changes

Demote all accounts to non-signer before invoking the transfer hook program. Let me know if you think the test is useless, I just wanted to be sure that the code was correct.

At the same time, remove cdylib target for the interface crate, and ~~remove the lib target for the program crate.~~ NOTE:  can't do the second one

cc @tiago18c