### PR TITLE
interface: Don't mark as cdylib

### DIFF
--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -30,7 +30,7 @@ spl-pod = "0.7.1"
 thiserror = "2.0"
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
#### Problem

The interface crate has a cdylib target, which makes it impossible to run LTO on it.

#### Summary of changes

Remove the cdylib target.