### PR TITLE
CI: Remove elgamal registry from publish job

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -66,7 +66,7 @@ jobs:
     needs: set_env
     uses: solana-program/actions/.github/workflows/publish-rust.yml@main
     with:
-      sbpf-program-packages: "program confidential-elgamal-registry"
+      sbpf-program-packages: "program"
       solana-cli-version: ${{ needs.set_env.outputs.SOLANA_CLI_VERSION }}
       clippy-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}
       rustfmt-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}


### PR DESCRIPTION
#### Problem

The publish job references the elgamal registry program, which is a copy-pasta error from token-2022.

#### Summary of changes

Remove the reference to the program.