### PR TITLE
deps: Update rustls-webpki, ignore for others

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5394,7 +5394,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -5444,7 +5444,7 @@ dependencies = [
  "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "security-framework 3.6.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -5469,9 +5469,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ audit:
 			--ignore RUSTSEC-2022-0093 \
 			--ignore RUSTSEC-2024-0421 \
 			--ignore RUSTSEC-2024-0344 \
+			--ignore RUSTSEC-2026-0098 \
+			--ignore RUSTSEC-2026-0099 \
 			$(ARGS)
 
 spellcheck:


### PR DESCRIPTION
#### Problem

The current version of rustls-webpki has a security advisory, but we can't update it everywhere.

#### Summary of changes

Bump the affected version where possible, ignore the rest.